### PR TITLE
prevent sequence build fail on Ubuntu 18.04+

### DIFF
--- a/SequenceAnalysis/pipeline_code/sequence_tools_install.sh
+++ b/SequenceAnalysis/pipeline_code/sequence_tools_install.sh
@@ -866,7 +866,24 @@ then
     echo "Compressing TAR"
     bzip2 fastx_toolkit-0.0.13.2.tar
     cd fastx_toolkit-0.0.13.2
-    ./configure --prefix=$LK_HOME
+
+    #
+    # on apt-based (Ubuntu) systems >= 18(.04), prevent the below from failing the build:
+    #
+    # fasta_formatter.cpp:105:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
+    #
+    if [ $(which apt-get) ]; then
+        source /etc/os-release
+
+        if [ "${VERSION_ID%%.*}" -ge 18 ]; then
+            CFLAGS=' -Wno-error=implicit-fallthrough ' ./configure --prefix=$LK_HOME
+        else
+            ./configure --prefix=$LK_HOME
+        fi
+    else
+        ./configure --prefix=$LK_HOME
+    fi
+
     make
     make install
 else


### PR DESCRIPTION
#### Rationale
Unable to build the sequencing tools with modern versions of Ubuntu.

In lieu of a more sophisticated platform/version detection mechanism, this compares the major version of `VERSION_ID` from `/etc/os-release` against `18` while defaulting to the plain `./configure` command. `/etc/os-release` should be available on all modern systemd based systems, but I've wrapped under `apt-get` protection since it's more reliably on Debian/Ubuntu systems.

Without this:
```
make[3]: Entering directory '<snip>/SequenceAnalysis/pipeline_code/build/tool_src/fastx_toolkit-0.0.13.2/src/fasta_formatter'
g++ -DHAVE_CONFIG_H -I. -I../.. -I/usr/include/gtextutils -I../libfastx     -g -O2 -Wall -Wextra -Wformat-nonliteral -Wformat-security -Wswitch-default -Wswitch-enum -Wunused-parameter -Wfloat-equal -Werror -DDEBUG -g -O1 -DDEBUG -g -O1 -MT fasta_formatter.o -MD -MP -MF .deps/fasta_formatter.Tpo -c -o fasta_formatter.o fasta_formatter.cpp
fasta_formatter.cpp: In function ‘void parse_command_line(int, char**)’:
fasta_formatter.cpp:105:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
  105 |    usage();
      |    ~~~~~^~
fasta_formatter.cpp:107:3: note: here
  107 |   case 'i':
      |   ^~~~
cc1plus: all warnings being treated as errors
make[3]: Leaving directory '<snip>/SequenceAnalysis/pipeline_code/build/tool_src/fastx_toolkit-0.0.13.2/src/fasta_formatter'
make[3]: *** [Makefile:315: fasta_formatter.o] Error 1
make[2]: Leaving directory '<snip>/SequenceAnalysis/pipeline_code/build/tool_src/fastx_toolkit-0.0.13.2/src'
make[2]: *** [Makefile:290: all-recursive] Error 1
make[1]: Leaving directory '<snip>/SequenceAnalysis/pipeline_code/build/tool_src/fastx_toolkit-0.0.13.2'
make[1]: *** [Makefile:318: all-recursive] Error 1
make: *** [Makefile:249: all] Error 2
```