### PR TITLE
Feat/plugin loading

### DIFF
--- a/jbrowse/resources/external/minimalSession.json
+++ b/jbrowse/resources/external/minimalSession.json
@@ -30,7 +30,10 @@
     }
   },
   "location": "1:196,734,341..197,535,702",
-
+  "nativePlugins": [
+    "VariantPlugin",
+    "MyProjectPlugin"
+  ],
   "tracks": [
     {
       "type": "VariantTrack",

--- a/jbrowse/src/client/JBrowse/Browser/Browser.tsx
+++ b/jbrowse/src/client/JBrowse/Browser/Browser.tsx
@@ -19,7 +19,6 @@ function generateViewState(genome, plugins, nativePlugins){
       assembly: genome.assembly ?? genome.assemblies,
       tracks: genome.tracks,
       configuration: genome.configuration,
-      //plugins: plugins.concat(VariantPlugin, MyProjectPlugin),
       plugins: plugins.concat(nativePlugins),
       location: genome.location,
       defaultSession: genome.defaultSession,
@@ -32,7 +31,6 @@ function View(){
     const session = queryParam.get('session')
     const nativePluginList = [MyProjectPlugin, VariantPlugin]
     const [state, setState] = useState(null);
-    //const [plugins, setPlugins] = useState<PluginConstructor[]>();
     useEffect(() => {
         Ajax.request({
             url: ActionURL.buildURL('jbrowse', 'getSession.api'),
@@ -51,7 +49,6 @@ function View(){
                     } catch (error) {
                         console.error("Error: ", error)
                     }
-                    //setPlugins(loadedPlugins);
                 } else {
                     loadedPlugins = []
                 }

--- a/jbrowse/src/client/JBrowse/Browser/Browser.tsx
+++ b/jbrowse/src/client/JBrowse/Browser/Browser.tsx
@@ -14,12 +14,13 @@ import VariantPlugin from "./plugins/VariantPlugin/index"
 
 const theme = createJBrowseTheme()
 
-function generateViewState(genome, plugins){
+function generateViewState(genome, plugins, nativePlugins){
   return createViewState({
       assembly: genome.assembly ?? genome.assemblies,
       tracks: genome.tracks,
       configuration: genome.configuration,
-      plugins: plugins.concat(VariantPlugin, MyProjectPlugin), //plugins,
+      //plugins: plugins.concat(VariantPlugin, MyProjectPlugin),
+      plugins: plugins.concat(nativePlugins),
       location: genome.location,
       defaultSession: genome.defaultSession,
       onChange: genome.onChange
@@ -29,9 +30,9 @@ function generateViewState(genome, plugins){
 function View(){
     const queryParam = new URLSearchParams(window.location.search);
     const session = queryParam.get('session')
-
+    const nativePluginList = [MyProjectPlugin, VariantPlugin]
     const [state, setState] = useState(null);
-    const [plugins, setPlugins] = useState<PluginConstructor[]>();
+    //const [plugins, setPlugins] = useState<PluginConstructor[]>();
     useEffect(() => {
         Ajax.request({
             url: ActionURL.buildURL('jbrowse', 'getSession.api'),
@@ -50,11 +51,21 @@ function View(){
                     } catch (error) {
                         console.error("Error: ", error)
                     }
-                    setPlugins(loadedPlugins);
+                    //setPlugins(loadedPlugins);
                 } else {
                     loadedPlugins = []
                 }
-                setState(generateViewState(jsonRes, loadedPlugins));
+                var nativePluginsSelected = []
+                if (jsonRes.nativePlugins != null){
+                    for(var i in jsonRes.nativePlugins){
+                        for(var j in nativePluginList){
+                            if (nativePluginList[j].name == jsonRes.nativePlugins[i]){
+                                nativePluginsSelected.push(nativePluginList[j])
+                            }
+                        }
+                    }
+                }
+                setState(generateViewState(jsonRes, loadedPlugins, nativePluginsSelected));
             },
             failure: function(res){
                 setState("invalid");


### PR DESCRIPTION
Added the ability to select project-specific plugins through the nativePlugins config property. Accepts a list of plugin names and if a matching name is found, the plugin is loaded. Does not load passed plugin names if the plugin cannot be found.

Browser.tsx will need to be updated in during development of further project-specific plugins to allow them to be loaded in this way. See Browser.tsx, line 32.