### PR TITLE
Fix Title Mapping

### DIFF
--- a/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.js
+++ b/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.js
@@ -84,10 +84,14 @@ export default jbrowse => {
                                     </div>
                             )
                         }
+                        let title = displays[display].properties[property]
+                        try{
+                           title = fields[title]["title"]
+                        } catch (e) {}
                         tempProp.push(
                                 <div key={property} className={classes.field}>
                                     <div className={classes.fieldName}>
-                                        {displays[display].properties[property]}
+                                        {title}
                                     </div>
                                     {children}
                                 </div>

--- a/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.js
+++ b/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.js
@@ -85,9 +85,12 @@ export default jbrowse => {
                             )
                         }
                         let title = displays[display].properties[property]
-                        try{
-                           title = fields[title]["title"]
-                        } catch (e) {}
+                        if(fields[title]){
+                           if(fields[title]["title"]){
+                              title = fields[title]["title"]
+                           }
+                        }
+
                         tempProp.push(
                                 <div key={property} className={classes.field}>
                                     <div className={classes.fieldName}>

--- a/jbrowse/test/src/org/labkey/test/tests/external/labModules/JBrowseTest.java
+++ b/jbrowse/test/src/org/labkey/test/tests/external/labModules/JBrowseTest.java
@@ -288,7 +288,7 @@ public class JBrowseTest extends BaseWebDriverTest
         WebElement toClick = getDriver().findElements(getVariantWithinTrack("mgap_hg38", "SNV T -> C", true)).stream().filter(WebElement::isDisplayed).collect(toSingleton()); // 1:116,981,406..116,981,406
         actions.click(toClick).perform();
         waitForElement(Locator.tagWithText("div", "1:116,981,406..116,981,406"));
-        assertElementPresent(Locator.tagWithText("div", "MismatchedRefAllele"));
+        assertElementPresent(Locator.tagWithText("div", "Minor Allele Frequency"));
     }
 
     private void testPredictedFunction()


### PR DESCRIPTION
Fixes ExtendedVariantWidget reading titles from fields.js, which broke in a previous update. 

Fixes the related test testTitleMapping(), which was passing when it should have failed.