### PR TITLE
Misc. style fixes

### DIFF
--- a/jbrowse/src/client/JBrowse/VariantTable/VariantTable.css
+++ b/jbrowse/src/client/JBrowse/VariantTable/VariantTable.css
@@ -19,3 +19,7 @@
 .menuItem {
     height: 100%;
 }
+
+.MuiTextField-root {
+    margin-top: 0px !important;
+}

--- a/jbrowse/src/client/JBrowse/VariantTable/components/VariantTableWidget.tsx
+++ b/jbrowse/src/client/JBrowse/VariantTable/components/VariantTableWidget.tsx
@@ -180,6 +180,7 @@ const VariantTableWidget = observer(props => {
     width: 50,
     flex: 1,
     headerAlign: 'left',
+    filterable: false,
     renderCell: (params: GridRenderCellParams) => {
       return (
           <>
@@ -258,7 +259,9 @@ const VariantTableWidget = observer(props => {
         </Grid>
       </div>
 
-      {gridElement}
+      <div style={{height: "calc(95% - 20px)"}}>
+        {gridElement}
+      </div>
     </>
   )
 })

--- a/jbrowse/src/client/JBrowse/VariantTable/constants.tsx
+++ b/jbrowse/src/client/JBrowse/VariantTable/constants.tsx
@@ -86,7 +86,7 @@ export const columns: GridColumns = [
   { field: 'impact', headerName: 'Impact', width: 50, type: "string", flex: 1, headerAlign: 'left' },
   { field: 'overlapping_genes', headerName: 'Overlapping Genes', type: "string", flex: 1, headerAlign: 'left' },
   { field: 'cadd_ph', headerName: 'CADD Score', width: 50, type: "number", flex: 1, headerAlign: 'left' },
-  { field: 'track_id', headerName: 'Track ID', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true, filterable: false},
-  { field: 'start', headerName: 'Start Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true, filterable: false },
-  { field: 'end', headerName: 'End Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true, filterable: false }
+  { field: 'track_id', headerName: 'Track ID', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true },
+  { field: 'start', headerName: 'Start Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true },
+  { field: 'end', headerName: 'End Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true }
 ]

--- a/jbrowse/src/client/JBrowse/VariantTable/constants.tsx
+++ b/jbrowse/src/client/JBrowse/VariantTable/constants.tsx
@@ -86,7 +86,7 @@ export const columns: GridColumns = [
   { field: 'impact', headerName: 'Impact', width: 50, type: "string", flex: 1, headerAlign: 'left' },
   { field: 'overlapping_genes', headerName: 'Overlapping Genes', type: "string", flex: 1, headerAlign: 'left' },
   { field: 'cadd_ph', headerName: 'CADD Score', width: 50, type: "number", flex: 1, headerAlign: 'left' },
-  { field: 'track_id', headerName: 'Track ID', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true },
-  { field: 'start', headerName: 'Start Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true },
-  { field: 'end', headerName: 'End Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true }
+  { field: 'track_id', headerName: 'Track ID', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true, filterable: false},
+  { field: 'start', headerName: 'Start Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true, filterable: false },
+  { field: 'end', headerName: 'End Location', width: 50, type: "string", flex: 1, headerAlign: 'left', hide: true, filterable: false }
 ]


### PR DESCRIPTION
* Fixes the misalignment of the Mui-datagrid filter modal
* Adds a 5% + 20px buffer to the bottom of the screen, to stop overlapping between the HTML footer and the table footer