### PR TITLE
Add missing gradle inputs/outputs to npm build tasks

### DIFF
--- a/jbrowse/build.gradle
+++ b/jbrowse/build.gradle
@@ -24,3 +24,17 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"), depProjectConfig: "published", depExtension: "module")
 }
+
+project.tasks.named("npm_run_build-prod").configure {
+    outputs.cacheIf { false }
+
+    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
+project.tasks.named("npm_run_build-dev").configure {
+    outputs.cacheIf { false }
+
+    inputs.dir(project.file("./node_modules/@jbrowse/cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir(project.file("./resources/external/jb-cli")).withPathSensitivity(PathSensitivity.RELATIVE)
+}


### PR DESCRIPTION
#### Rationale
jbrowse command line tool needs to be in task inputs/outputs for Gradle to cache/build properly.
I recommend copying this branch to your repository with a `22.7_fb_` branch name to let TeamCity verify it.

#### Related Pull Requests
* N/A

#### Changes
* Add missing gradle inputs/outputs to npm build tasks.
