### PR TITLE
Add LRUQueryCache

### DIFF
--- a/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseService.java
+++ b/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseService.java
@@ -48,6 +48,8 @@ abstract public class JBrowseService
 
     abstract public void registerLuceneIndexDetector(LuceneIndexDetector detector);
 
+    abstract public void cacheDefaultQuery(User u, String sessionId, String trackId);
+
     public interface LuceneIndexDetector
     {
         SequenceOutputFile findMatchingLuceneIndex(SequenceOutputFile vcfFile, List<String> infoFieldsToIndex, User u, @Nullable Logger log) throws PipelineJobException;

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseController.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseController.java
@@ -1035,5 +1035,15 @@ public class JBrowseController extends SpringActionController
             this.includeDefaultFields = includeDefaultFields;
         }
     }
+
+    @RequiresPermission(ReadPermission.class)
+    public static class GetLuceneCacheInfoAction extends ReadOnlyApiAction<Object>
+    {
+        @Override
+        public ApiResponse execute(Object form, BindException errors)
+        {
+            return new ApiSimpleResponse("cacheInfo", JBrowseLuceneSearch.reportCacheInfo());
+        }
+    }
 }
 

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
@@ -1,6 +1,7 @@
 package org.labkey.jbrowse;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -39,6 +40,7 @@ import org.labkey.api.jbrowse.JBrowseFieldDescriptor;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.jbrowse.model.JBrowseSession;
 import org.labkey.jbrowse.model.JsonFile;
 
@@ -64,6 +66,7 @@ import static org.labkey.jbrowse.JBrowseFieldUtils.getTrack;
 
 public class JBrowseLuceneSearch
 {
+    private static final Logger _log = LogHelper.getLogger(JBrowseLuceneSearch.class, "Logger related to JBrowse/Lucene indexing and queries");
     private final JBrowseSession _session;
     private final JsonFile _jsonFile;
     private final User _user;
@@ -413,11 +416,12 @@ public class JBrowseLuceneSearch
     {
         try
         {
+            JBrowseLuceneSearch.clearCache(_jsonFile.getObjectId());
             doSearch(_user, ALL_DOCS, 100, 0, GENOMIC_POSITION, false);
         }
         catch (ParseException | IOException e)
         {
-
+            _log.error("Unable to cache default query for: " + _jsonFile.getObjectId(), e);
         }
     }
 

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
@@ -409,6 +409,18 @@ public class JBrowseLuceneSearch
         return cacheInfo;
     }
 
+    public void cacheDefaultQuery()
+    {
+        try
+        {
+            doSearch(_user, ALL_DOCS, 100, 0, GENOMIC_POSITION, false);
+        }
+        catch (ParseException | IOException e)
+        {
+
+        }
+    }
+
     public static void clearCache(@Nullable String jbrowseTrackId)
     {
         if (jbrowseTrackId == null)

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
@@ -366,8 +366,13 @@ public class JBrowseLuceneSearch
 
         @Override
         public boolean shouldCache(Query query) throws IOException {
-            if (query instanceof MatchAllDocsQuery) {
-                return true;
+            if (query instanceof BooleanQuery) {
+                BooleanQuery bq = (BooleanQuery) query;
+                for (BooleanClause clause : bq) {
+                    if (clause.getQuery() instanceof MatchAllDocsQuery) {
+                        return true;
+                    }
+                }
             }
 
             return defaultPolicy.shouldCache(query);

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
@@ -312,6 +312,13 @@ public class JBrowseServiceImpl extends JBrowseService
         _detectors.add(detector);
     }
 
+    @Override
+    public void cacheDefaultQuery(User u, String sessionId, String trackId)
+    {
+        JBrowseLuceneSearch luceneSearch = JBrowseLuceneSearch.create(sessionId, trackId, u);
+        luceneSearch.cacheDefaultQuery();
+    }
+
     public static final class DefaultLuceneIndexDetector implements LuceneIndexDetector
     {
         @Override

--- a/jbrowse/src/org/labkey/jbrowse/model/JsonFile.java
+++ b/jbrowse/src/org/labkey/jbrowse/model/JsonFile.java
@@ -50,9 +50,9 @@ import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.UnauthorizedException;
+import org.labkey.jbrowse.JBrowseLuceneSearch;
 import org.labkey.jbrowse.JBrowseManager;
 import org.labkey.jbrowse.JBrowseSchema;
-import org.labkey.jbrowse.pipeline.IndexVariantsStep;
 import org.labkey.jbrowse.pipeline.JBrowseLucenePipelineJob;
 import org.labkey.sequenceanalysis.run.util.TabixRunner;
 
@@ -964,6 +964,8 @@ public class JsonFile
             }
             else if (existingLuceneDir != null && existingLuceneDir.exists())
             {
+                JBrowseLuceneSearch.clearCache(getObjectId());
+
                 // Note: this could exist, but be an empty folder:
                 if (luceneDir.exists())
                 {
@@ -1004,7 +1006,7 @@ public class JsonFile
                     try
                     {
                         PipeRoot root = PipelineService.get().getPipelineRootSetting(getContainerObj());
-                        PipelineService.get().queueJob(new JBrowseLucenePipelineJob(getContainerObj(), null, root, vcf, luceneDir, getInfoFieldsToIndex(), allowLenientLuceneProcessing()));
+                        PipelineService.get().queueJob(new JBrowseLucenePipelineJob(getContainerObj(), null, root, getObjectId(), vcf, luceneDir, getInfoFieldsToIndex(), allowLenientLuceneProcessing()));
                     }
                     catch (PipelineValidationException e)
                     {
@@ -1030,6 +1032,7 @@ public class JsonFile
                 if (forceReprocess || !doesLuceneIndexExist())
                 {
                     JBrowseLucenePipelineJob.prepareLuceneIndex(targetFile, luceneDir, log, getInfoFieldsToIndex(), allowLenientLuceneProcessing());
+                    JBrowseLuceneSearch.clearCache(getObjectId());
                 }
                 else
                 {

--- a/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseLuceneFinalTask.java
+++ b/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseLuceneFinalTask.java
@@ -1,0 +1,84 @@
+package org.labkey.jbrowse.pipeline;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.pipeline.AbstractTaskFactory;
+import org.labkey.api.pipeline.AbstractTaskFactorySettings;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineJobException;
+import org.labkey.api.pipeline.PipelineJobService;
+import org.labkey.api.pipeline.RecordedAction;
+import org.labkey.api.pipeline.RecordedActionSet;
+import org.labkey.api.util.FileType;
+import org.labkey.jbrowse.JBrowseLuceneSearch;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * User: bbimber
+ * Date: 8/6/12
+ * Time: 12:57 PM
+ */
+public class JBrowseLuceneFinalTask extends PipelineJob.Task<JBrowseLuceneFinalTask.Factory>
+{
+    protected JBrowseLuceneFinalTask(Factory factory, PipelineJob job)
+    {
+        super(factory, job);
+    }
+
+    public static class Factory extends AbstractTaskFactory<AbstractTaskFactorySettings, Factory>
+    {
+        public Factory()
+        {
+            super(JBrowseLuceneFinalTask.class);
+        }
+
+        @Override
+        public List<FileType> getInputTypes()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getStatusName()
+        {
+            return PipelineJob.TaskStatus.running.toString();
+        }
+
+        @Override
+        public List<String> getProtocolActionNames()
+        {
+            return List.of("JBrowse-Lucene-Finalize");
+        }
+
+        @Override
+        public PipelineJob.Task<?> createTask(PipelineJob job)
+        {
+            return new JBrowseLuceneFinalTask(this, job);
+        }
+
+        @Override
+        public boolean isJobComplete(PipelineJob job)
+        {
+            return false;
+        }
+    }
+
+    @Override
+    @NotNull
+    public RecordedActionSet run() throws PipelineJobException
+    {
+        if (PipelineJobService.get().getLocationType() != PipelineJobService.LocationType.WebServer)
+        {
+            throw new PipelineJobException("This task must run on the webserver!");
+        }
+
+        JBrowseLuceneSearch.clearCache(getPipelineJob().getJbrowseTrackId());
+        return new RecordedActionSet(Collections.singleton(new RecordedAction("JBrowse-Lucene")));
+    }
+
+    private JBrowseLucenePipelineJob getPipelineJob()
+    {
+        return (JBrowseLucenePipelineJob)getJob();
+    }
+}

--- a/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseLucenePipelineJob.java
+++ b/jbrowse/src/org/labkey/jbrowse/pipeline/JBrowseLucenePipelineJob.java
@@ -39,6 +39,7 @@ import java.util.List;
 public class JBrowseLucenePipelineJob extends PipelineJob
 {
     private List<String> _infoFields;
+    private String _jbrowseTrackId;
     private File _vcf;
     private File _targetDir;
     private boolean _allowLenientLuceneProcessing = false;
@@ -48,9 +49,10 @@ public class JBrowseLucenePipelineJob extends PipelineJob
     {
     }
 
-    public JBrowseLucenePipelineJob(Container c, User user, PipeRoot pipeRoot, File vcf, File targetDir, List<String> infoFields, boolean allowLenientLuceneProcessing)
+    public JBrowseLucenePipelineJob(Container c, User user, PipeRoot pipeRoot, String jbrowseTrackId, File vcf, File targetDir, List<String> infoFields, boolean allowLenientLuceneProcessing)
     {
         super(JBrowseLucenePipelineProvider.NAME, new ViewBackgroundInfo(c, user, null), pipeRoot);
+        _jbrowseTrackId = jbrowseTrackId;
         _vcf = vcf;
         _targetDir = targetDir;
         _infoFields = infoFields;
@@ -90,7 +92,7 @@ public class JBrowseLucenePipelineJob extends PipelineJob
     }
 
     @Override
-    public TaskPipeline getTaskPipeline()
+    public TaskPipeline<?> getTaskPipeline()
     {
         return PipelineJobService.get().getTaskPipeline(new TaskId(JBrowseLucenePipelineJob.class));
     }
@@ -103,6 +105,16 @@ public class JBrowseLucenePipelineJob extends PipelineJob
     public void setInfoFields(List<String> infoFields)
     {
         _infoFields = infoFields;
+    }
+
+    public String getJbrowseTrackId()
+    {
+        return _jbrowseTrackId;
+    }
+
+    public void setJbrowseTrackId(String jbrowseTrackId)
+    {
+        _jbrowseTrackId = jbrowseTrackId;
     }
 
     public File getVcf()

--- a/jbrowse/webapp/WEB-INF/jbrowse/jbrowseContext.xml
+++ b/jbrowse/webapp/WEB-INF/jbrowse/jbrowseContext.xml
@@ -8,6 +8,7 @@
             <list>
                 <bean class="org.labkey.jbrowse.pipeline.JBrowseSessionTask$Factory"/>
                 <bean class="org.labkey.jbrowse.pipeline.JBrowseLuceneTask$Factory"/>
+                <bean class="org.labkey.jbrowse.pipeline.JBrowseLuceneFinalTask$Factory"/>
             </list>
         </property>
         <property name="pipelines">
@@ -25,6 +26,7 @@
                     <property name="taskProgressionSpec">
                         <list>
                             <value type="java.lang.Class">org.labkey.jbrowse.pipeline.JBrowseLuceneTask</value>
+                            <value type="java.lang.Class">org.labkey.jbrowse.pipeline.JBrowseLuceneFinalTask</value>
                         </list>
                     </property>
                 </bean>


### PR DESCRIPTION
Implementing a lucene caching strategy per session could look something like this. At the moment, the only weirdness I'm seeing is that whether or not a query actually gets cached is dependent on the caching policy, and UsageTrackingQueryCachingPolicy may not be the best choice given that many queries are pretty specific to individual users. To ensure searchString=all is always cached, we might need to implement the interface ourselves and make sure that all MatchAllDocsQueries are cached by default.