### PR TITLE
Caching fix

### DIFF
--- a/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseService.java
+++ b/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseService.java
@@ -57,5 +57,5 @@ abstract public class JBrowseService
         boolean isAvailable(Container c);
     }
 
-    abstract public void clearLuceneCacheEntry(String trackObjectId);
+    abstract public void clearLuceneCacheEntry(File luceneIndexDir);
 }

--- a/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseService.java
+++ b/jbrowse/api-src/org/labkey/api/jbrowse/JBrowseService.java
@@ -56,4 +56,6 @@ abstract public class JBrowseService
 
         boolean isAvailable(Container c);
     }
+
+    abstract public void clearLuceneCacheEntry(String trackObjectId);
 }

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseLuceneSearch.java
@@ -40,6 +40,7 @@ import org.labkey.api.jbrowse.JBrowseFieldDescriptor;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.jbrowse.model.JBrowseSession;
 import org.labkey.jbrowse.model.JsonFile;
@@ -448,6 +449,11 @@ public class JBrowseLuceneSearch
         }
     }
 
+    public static void emptyCache()
+    {
+        clearCache(null);
+    }
+
     public static void clearCache(@Nullable String jbrowseTrackId)
     {
         if (jbrowseTrackId == null)
@@ -457,6 +463,28 @@ public class JBrowseLuceneSearch
         else
         {
             _cache.remove(jbrowseTrackId);
+        }
+    }
+
+    public static class ShutdownHandler implements ShutdownListener
+    {
+        @Override
+        public String getName()
+        {
+            return "JBrowse-Lucene Shutdown Listener";
+        }
+
+        @Override
+        public void shutdownPre()
+        {
+
+        }
+
+        @Override
+        public void shutdownStarted()
+        {
+            _log.info("Clearing all open JBrowse/Lucene cached readers");
+            JBrowseLuceneSearch.emptyCache();
         }
     }
 }

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseModule.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseModule.java
@@ -30,6 +30,7 @@ import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.sequenceanalysis.SequenceAnalysisService;
 import org.labkey.api.sequenceanalysis.pipeline.SequencePipelineService;
 import org.labkey.api.settings.AdminConsole;
+import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.view.WebPartFactory;
@@ -110,6 +111,8 @@ public class JBrowseModule extends ExtendedSimpleModule
 
         JBrowseService.get().registerFieldCustomizer(new JBrowseLuceneSearch.DefaultJBrowseFieldCustomizer());
         JBrowseService.get().registerGroupsProvider(new JBrowseLuceneSearch.TestJBrowseGroupProvider());
+
+        ContextListener.addShutdownListener(new JBrowseLuceneSearch.ShutdownHandler());
     }
 
     public static void registerPipelineSteps()

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
@@ -320,9 +320,9 @@ public class JBrowseServiceImpl extends JBrowseService
     }
 
     @Override
-    public void clearLuceneCacheEntry(String trackObjectId)
+    public void clearLuceneCacheEntry(File luceneIndexDir)
     {
-        JBrowseLuceneSearch.clearCache(trackObjectId);
+        JBrowseLuceneSearch.clearCacheForFile(luceneIndexDir);
     }
 
     public static final class DefaultLuceneIndexDetector implements LuceneIndexDetector

--- a/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
+++ b/jbrowse/src/org/labkey/jbrowse/JBrowseServiceImpl.java
@@ -319,6 +319,12 @@ public class JBrowseServiceImpl extends JBrowseService
         luceneSearch.cacheDefaultQuery();
     }
 
+    @Override
+    public void clearLuceneCacheEntry(String trackObjectId)
+    {
+        JBrowseLuceneSearch.clearCache(trackObjectId);
+    }
+
     public static final class DefaultLuceneIndexDetector implements LuceneIndexDetector
     {
         @Override


### PR DESCRIPTION
Caching was getting aggressively emptied because Lucene has a callback running on a loop internally that empties the cache if the IndexReader gets garbage collected. This patch caches the IndexReader per-session alongside the LRUQueryCache and slightly modifies the caching policy, which should improve the cache's behavior in prod.