### PR TITLE
Change mismatch threshold for lenient profile

### DIFF
--- a/singlecell/src/org/labkey/singlecell/run/NimbleHelper.java
+++ b/singlecell/src/org/labkey/singlecell/run/NimbleHelper.java
@@ -339,7 +339,7 @@ public class NimbleHelper
             String alignTemplate = genome.getTemplate();
             if ("lenient".equals(alignTemplate))
             {
-                config.put("num_mismatches", 5);
+                config.put("num_mismatches", 2);
                 config.put("intersect_level", 0);
                 config.put("score_threshold", 45);
                 config.put("score_percent", 0.45);


### PR DESCRIPTION
I checked to see if we were getting antisense hits that shouldn't be contaminating the results for LILRB3, and it seems like only the expected orientations are being let through. I'm adding a flag to optionally report antisense hits as a separate feature rather than discarding them. The vast majority of the reads in the nimble-only subset I sent you (i.e. that aren't placed in the expected location despite getting called for the feature) get filtered out if we lower the gap size, so I'd like to try that. It could be worth doing something in NimbleAlignPanel.js to make that value configurable per job but at the moment based on what I'm seeing from the subset data, this would solve most of the noisiness issues with LILRB3 and STAT3, alongside with a bugfix I made in the aligner.
