### PR TITLE
Constrain popup dialog height in JBrowse

### DIFF
--- a/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.tsx
+++ b/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.tsx
@@ -407,7 +407,7 @@ export default jbrowse => {
         feat["INFO"] = null
 
         return (
-                <Paper data-testid="extended-variant-widget">
+                <Paper data-testid="extended-variant-widget" style={{height: '50%', overflowY: 'scroll'}}>
                     {message}
                     <FeatureDetails
                             feature={feat}

--- a/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.tsx
+++ b/jbrowse/src/client/JBrowse/Browser/plugins/ExtendedVariantPlugin/ExtendedVariantWidget/ExtendedVariantWidget.tsx
@@ -407,7 +407,7 @@ export default jbrowse => {
         feat["INFO"] = null
 
         return (
-                <Paper data-testid="extended-variant-widget" style={{height: '50%', overflowY: 'scroll'}}>
+                <Paper data-testid="extended-variant-widget" style={{height: '100vh', overflowY: 'scroll'}}>
                     {message}
                     <FeatureDetails
                             feature={feat}


### PR DESCRIPTION
This link should repro this: http://localhost:8080/home/jbrowse-browser.view?session=mgap

I posted the question to JBrowse and apparently this does not happen in all cases. This link shows their browser, which does overflow/scroll appropriately: https://jbrowse.org/storybook/lgv/main/?path=/story/source-code-for-examples--one-linear-genome-view

Also some discussion here: https://github.com/GMOD/jbrowse-components/issues/4604#issuecomment-2418146193. Their devs are good at questions and may have pointers if this is hard to investigate. I did not find the code in jbrowse itself that creates the Dialog, but I think we might need to find that to debug this. 
