### PR TITLE
Zip metadata files

### DIFF
--- a/singlecell/resources/chunks/Functions.R
+++ b/singlecell/resources/chunks/Functions.R
@@ -107,7 +107,7 @@ saveData <- function(seuratObj, datasetId) {
     # Write cell barcodes and metadata:
     metaDf <- seuratObj@meta.data
     metaDf$cellbarcode <- colnames(seuratObj)
-    write.table(metaDf, file = metaFile, quote = T, row.names = F, sep = ',', col.names = T)
+    write.table(metaDf, file = gzfile(metaFile), quote = T, row.names = F, sep = ',', col.names = T)
     write.table(data.frame(CellBarcode = colnames(seuratObj)), file = barcodeFile, quote = F, row.names = F, sep = ',', col.names = F)
 }
 


### PR DESCRIPTION
#### Rationale
Currently, when saving the metadata to disk, the files aren't gzipped, although I believe this is the intention given the file name here: 
https://github.com/BimberLab/DiscvrLabKeyModules/blob/35255c65950b0720cc59658bbb06e9b187c4f270/singlecell/resources/chunks/Functions.R#L84


#### Related Pull Requests
entertainingly, this is likely why the metadata files are probably large here: https://github.com/bimberlabinternal/Rdiscvr/issues/68 but nothing direct. 

#### Changes
single line change here to zip the file, which should automatically clean up the connection as well. 
https://github.com/BimberLab/DiscvrLabKeyModules/blob/35255c65950b0720cc59658bbb06e9b187c4f270/singlecell/resources/chunks/Functions.R#L110